### PR TITLE
handle improper models

### DIFF
--- a/R/set_confounds.R
+++ b/R/set_confounds.R
@@ -106,6 +106,7 @@
 
 set_confound <- function(model, confound = NULL, add_confounds_df = TRUE) {
 
+    model_0 <- model
     # Housekeeping
     if (is.null(confound)) {
         message("No confound provided")
@@ -220,6 +221,15 @@ set_confound <- function(model, confound = NULL, add_confounds_df = TRUE) {
 
     attr(model$P, "confounds_df") <- model$confounds_df
     attr(model$P, "param_set") <- unique(model$parameters_df$param_set)
+
+    parameters <- suppressMessages(get_param_dist(model, n_draws = 1, using = "priors"))
+    prob_of_s <- get_type_prob(model, model$P, parameters = parameters)
+
+
+    if(round(sum(prob_of_s),6) != "1"){ #Very hacky and ugly: Didn't work with numeric comparison-- even when comparing against 1L
+        warning("Cannot characterize confounding; no action taken")
+        return(model_0)
+    }
     # Export
     model
 

--- a/tests/testthat/test_set_confounds.R
+++ b/tests/testthat/test_set_confounds.R
@@ -19,3 +19,13 @@ testthat::test_that(
 	}
 )
 
+
+testthat::test_that(
+
+  desc = "set_confound warns when prob of types is greater than 1",
+
+  code = {
+    model <- make_model("X -> Y <- M")
+    expect_warning(set_confound(model, confound = list(M = "Y[X=1]==1")))
+  }
+)


### PR DESCRIPTION
Edits to set_confounds to handle improper confound restrictions: check whether sum of probability types is different than 1.
New test to check that edits work 

